### PR TITLE
legacy onnx opset

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ NanoOWL runs real-time on Jetson Orin Nano.
     python3 owl_predict.py \
         --prompt="[an owl, a glove]" \
         --threshold=0.1 \
-        --image_encoder_engine=../data/owl_image_encoder_engine_patch32.engine
+        --image_encoder_engine=../data/owl_image_encoder_patch32.engine
     ```
 
 That's it!  If everything is working properly, you should see a visualization saved to ``data/owl_predict_out.jpg``.  
@@ -137,7 +137,7 @@ Then run the example
 python3 owl_predict.py \
     --prompt="[an owl, a glove]" \
     --threshold=0.1 \
-    --image_encoder_engine=../data/owl_image_encoder_engine_patch32.engine
+    --image_encoder_engine=../data/owl_image_encoder_patch32.engine
 ```
 
 By default the output will be saved to ``data/owl_predict_out.jpg``. 
@@ -164,7 +164,7 @@ of interest, type
 python3 tree_predict.py \
     --prompt="[an owl [a wing, an eye]]" \
     --threshold=0.15 \
-    --image_encoder_engine=../data/owl_image_encoder_engine_patch32.engine
+    --image_encoder_engine=../data/owl_image_encoder_patch32.engine
 ```
 
 By default the output will be saved to ``data/tree_predict_out.jpg``.
@@ -175,7 +175,7 @@ To classify the image as indoors or outdoors, type
 python3 tree_predict.py \
     --prompt="(indoors, outdoors)" \
     --threshold=0.15 \
-    --image_encoder_engine=../data/owl_image_encoder_engine_patch32.engine
+    --image_encoder_engine=../data/owl_image_encoder_patch32.engine
 ```
 
 To classify the image as indoors or outdoors, and if it's outdoors then detect
@@ -185,7 +185,7 @@ all owls, type
 python3 tree_predict.py \
     --prompt="(indoors, outdoors [an owl])" \
     --threshold=0.15 \
-    --image_encoder_engine=../data/owl_image_encoder_engine_patch32.engine
+    --image_encoder_engine=../data/owl_image_encoder_patch32.engine
 ```
 
 

--- a/nanoowl/build_image_encoder_engine.py
+++ b/nanoowl/build_image_encoder_engine.py
@@ -33,5 +33,6 @@ if __name__ == "__main__":
 
     predictor.build_image_encoder_engine(
         args.output_path,
-        fp16_mode=args.fp16_mode
+        fp16_mode=args.fp16_mode,
+        onnx_opset=args.onnx_opset
     )

--- a/nanoowl/build_image_encoder_engine.py
+++ b/nanoowl/build_image_encoder_engine.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     parser.add_argument("output_path", type=str)
     parser.add_argument("--model_name", type=str, default="google/owlvit-base-patch32")
     parser.add_argument("--fp16_mode", type=bool, default=True)
-    parser.add_argument("--onnx_opset", type=int, default=17)
+    parser.add_argument("--onnx_opset", type=int, default=16)
     args = parser.parse_args()
     
     predictor = OwlPredictor(

--- a/nanoowl/build_image_encoder_engine.py
+++ b/nanoowl/build_image_encoder_engine.py
@@ -24,6 +24,7 @@ if __name__ == "__main__":
     parser.add_argument("output_path", type=str)
     parser.add_argument("--model_name", type=str, default="google/owlvit-base-patch32")
     parser.add_argument("--fp16_mode", type=bool, default=True)
+    parser.add_argument("--onnx_opset", type=int, default=17)
     args = parser.parse_args()
     
     predictor = OwlPredictor(

--- a/nanoowl/owl_predictor.py
+++ b/nanoowl/owl_predictor.py
@@ -416,12 +416,18 @@ class OwlPredictor(torch.nn.Module):
 
         return image_encoder
 
-    def build_image_encoder_engine(self, engine_path: str, max_batch_size: int = 1, fp16_mode = True, onnx_path: Optional[str] = None):
+    def build_image_encoder_engine(self, 
+            engine_path: str, 
+            max_batch_size: int = 1, 
+            fp16_mode = True, 
+            onnx_path: Optional[str] = None,
+            onnx_opset: int = 17
+        ):
 
         if onnx_path is None:
             onnx_dir = tempfile.mkdtemp()
             onnx_path = os.path.join(onnx_dir, "image_encoder.onnx")
-            self.export_image_encoder_onnx(onnx_path)
+            self.export_image_encoder_onnx(onnx_path, onnx_opset=onnx_opset)
 
         args = ["/usr/src/tensorrt/bin/trtexec"]
     


### PR DESCRIPTION
adds ability to support <17 opset versions to get past legacy TRT conversion error

to use:

```bash
python3 -m nanoowl.build_image_encoder_engine data/owl_image_encoder_patch32.engine --onnx_opset=16
```