### PR TITLE
Add thresholds per object for owl_predictor

### DIFF
--- a/examples/owl_predict.py
+++ b/examples/owl_predict.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--image", type=str, default="../assets/owl_glove_small.jpg")
     parser.add_argument("--prompt", type=str, default="an owl, a glove")
-    parser.add_argument("--thresholds", type=str, default="0.1,0.1")
+    parser.add_argument("--threshold", type=str, default="0.1,0.1")
     parser.add_argument("--output", type=str, default="../data/owl_predict_out.jpg")
     parser.add_argument("--model", type=str, default="google/owlvit-base-patch32")
     parser.add_argument("--image_encoder_engine", type=str, default="../data/owl_image_encoder_patch32.engine")
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     text = prompt.split(',')
     print(text)
 
-    thresholds = args.thresholds.strip("][()")
+    thresholds = args.threshold.strip("][()")
     thresholds = thresholds.split(',')
     thresholds = [float(x) for x in thresholds]
     print(thresholds)
@@ -62,7 +62,7 @@ if __name__ == "__main__":
         image=image, 
         text=text, 
         text_encodings=text_encodings,
-        thresholds=thresholds,
+        threshold=thresholds,
         pad_square=False
     )
 

--- a/examples/owl_predict.py
+++ b/examples/owl_predict.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
                 image=image, 
                 text=text, 
                 text_encodings=text_encodings,
-                thresholds=thresholds,
+                threshold=thresholds,
                 pad_square=False
             )
         torch.cuda.current_stream().synchronize()

--- a/examples/owl_predict.py
+++ b/examples/owl_predict.py
@@ -30,20 +30,24 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--image", type=str, default="../assets/owl_glove_small.jpg")
-    parser.add_argument("--prompt", type=str, default="")
-    parser.add_argument("--threshold", type=float, default=0.1)
+    parser.add_argument("--prompt", type=str, default="an owl, a glove")
+    parser.add_argument("--thresholds", type=str, default="0.1,0.1")
     parser.add_argument("--output", type=str, default="../data/owl_predict_out.jpg")
     parser.add_argument("--model", type=str, default="google/owlvit-base-patch32")
-    parser.add_argument("--image_encoder_engine", type=str, default="../data/owlvit_image_encoder_patch32.engine")
+    parser.add_argument("--image_encoder_engine", type=str, default="../data/owl_image_encoder_patch32.engine")
     parser.add_argument("--profile", action="store_true")
     parser.add_argument("--num_profiling_runs", type=int, default=30)
     args = parser.parse_args()
 
     prompt = args.prompt.strip("][()")
-
     text = prompt.split(',')
-    
     print(text)
+
+    thresholds = args.thresholds.strip("][()")
+    thresholds = thresholds.split(',')
+    thresholds = [float(x) for x in thresholds]
+    print(thresholds)
+    
 
     predictor = OwlPredictor(
         args.model,
@@ -58,7 +62,7 @@ if __name__ == "__main__":
         image=image, 
         text=text, 
         text_encodings=text_encodings,
-        threshold=args.threshold,
+        thresholds=thresholds,
         pad_square=False
     )
 
@@ -70,7 +74,7 @@ if __name__ == "__main__":
                 image=image, 
                 text=text, 
                 text_encodings=text_encodings,
-                threshold=args.threshold,
+                thresholds=thresholds,
                 pad_square=False
             )
         torch.cuda.current_stream().synchronize()

--- a/examples/tree_predict.py
+++ b/examples/tree_predict.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     parser.add_argument("--threshold", type=float, default=0.1)
     parser.add_argument("--output", type=str, default="../data/tree_predict_out.jpg")
     parser.add_argument("--model", type=str, default="google/owlvit-base-patch32")
-    parser.add_argument("--image_encoder_engine", type=str, default="../data/owlvit_image_encoder_patch32.engine")
+    parser.add_argument("--image_encoder_engine", type=str, default="../data/owl_image_encoder_patch32.engine")
     args = parser.parse_args()
 
     predictor = TreePredictor(

--- a/nanoowl/owl_predictor.py
+++ b/nanoowl/owl_predictor.py
@@ -274,8 +274,11 @@ class OwlPredictor(torch.nn.Module):
     def decode(self, 
             image_output: OwlEncodeImageOutput, 
             text_output: OwlEncodeTextOutput,
-            thresholds: List[float],
+            threshold: Union[int, float, List[Union[int, float]]] = 0.1,
         ) -> OwlDecodeOutput:
+
+        if isinstance(threshold, (int, float)):
+            threshold = [threshold]
 
         num_input_images = image_output.image_class_embeds.shape[0]
 
@@ -291,9 +294,9 @@ class OwlPredictor(torch.nn.Module):
         labels = scores_max.indices
         scores = scores_max.values
         masks = []
-        for i, threshold in enumerate(thresholds):
+        for i, thresh in enumerate(threshold):
             label_mask = labels == i
-            score_mask = scores > threshold 
+            score_mask = scores > thresh
             obj_mask = torch.logical_and(label_mask,score_mask)
             masks.append(obj_mask) 
         
@@ -455,7 +458,7 @@ class OwlPredictor(torch.nn.Module):
             image: PIL.Image, 
             text: List[str], 
             text_encodings: Optional[OwlEncodeTextOutput],
-            thresholds: List[float],
+            threshold: Union[int, float, List[Union[int, float]]] = 0.1,
             pad_square: bool = True,
             
         ) -> OwlDecodeOutput:
@@ -469,5 +472,5 @@ class OwlPredictor(torch.nn.Module):
 
         image_encodings = self.encode_rois(image_tensor, rois, pad_square=pad_square)
 
-        return self.decode(image_encodings, text_encodings, thresholds)
+        return self.decode(image_encodings, text_encodings, threshold)
 


### PR DESCRIPTION
Changes the owl_predictor to accept a list of floats for the thresholds instead of a single value. Each threshold applies to an object in the prompt at the same index. 

I did not add support for the tree predictor so there will be errors if you use the tree predictor with these changes.

This change could just go under an experimental branch.  