### PR TITLE
Make camera a parameter

### DIFF
--- a/examples/tree_demo/tree_demo.py
+++ b/examples/tree_demo/tree_demo.py
@@ -38,9 +38,10 @@ if __name__ == "__main__":
     parser.add_argument("--image_quality", type=int, default=50)
     parser.add_argument("--port", type=int, default=7860)
     parser.add_argument("--host", type=str, default="0.0.0.0")
+    parser.add_argument("--camera", type=int, default=0)
     args = parser.parse_args()
 
-    CAMERA_DEVICE = 0
+    CAMERA_DEVICE = args.camera
     IMAGE_QUALITY = args.image_quality
 
     predictor = TreePredictor(


### PR DESCRIPTION
Tiny PR, but seems like a good fix. My Realsense camera shows up as multiple `/dev/video*` devices, and this helps to make it run easier.

Thanks for the work!