### PR TITLE
Changes in the prerequisites in the Readme Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ NanoOWL runs real-time on Jetson Orin Nano.
     5. (optional) Install NanoSAM (for the instance segmentation example)
     6. Install the Clip Package
 
-        ```conda install --yes -c pytorch pytorch=1.7.1 torchvision cudatoolkit=11.0
-           pip install ftfy regex tqdm
-           pip install git+https://github.com/openai/CLIP.git
+        ```bash
+        conda install --yes -c pytorch pytorch=1.7.1 torchvision cudatoolkit=11.0
+        pip install ftfy regex tqdm
+        pip install git+https://github.com/openai/CLIP.git
         ```
 
 2. Install the NanoOWL package.
@@ -117,7 +118,7 @@ NanoOWL runs real-time on Jetson Orin Nano.
     cd examples
     python3 owl_predict.py \
         --prompt="[an owl, a glove]" \
-        --threshold=0.1 \
+        --threshold="0.1. 0.1" \
         --image_encoder_engine=../data/owl_image_encoder_patch32.engine
     ```
 
@@ -144,7 +145,7 @@ Then run the example
 ```bash
 python3 owl_predict.py \
     --prompt="[an owl, a glove]" \
-    --threshold=0.1 \
+    --threshold="0.1, 0.1" \
     --image_encoder_engine=../data/owl_image_encoder_patch32.engine
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ NanoOWL runs real-time on Jetson Orin Nano.
         pip install ftfy regex tqdm
         pip install git+https://github.com/openai/CLIP.git
         ```
+    7. Install the aiohttp module
+
+        ```bash
+        python3 -m pip install aiohttp
+        ```
 
 2. Install the NanoOWL package.
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ NanoOWL runs real-time on Jetson Orin Nano.
     cd examples
     python3 owl_predict.py \
         --prompt="[an owl, a glove]" \
-        --threshold="0.1. 0.1" \
+        --threshold=0.1 \
         --image_encoder_engine=../data/owl_image_encoder_patch32.engine
     ```
 
@@ -145,7 +145,7 @@ Then run the example
 ```bash
 python3 owl_predict.py \
     --prompt="[an owl, a glove]" \
-    --threshold="0.1, 0.1" \
+    --threshold=0.1 \
     --image_encoder_engine=../data/owl_image_encoder_patch32.engine
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,13 +80,19 @@ NanoOWL runs real-time on Jetson Orin Nano.
     1. Install PyTorch
 
     2. Install [torch2trt](https://github.com/NVIDIA-AI-IOT/torch2trt)
-    3. Install NVIDIA TensorRT
+    3. Install NVIDIA [TensorRT](https://github.com/NVIDIA/TensorRT)
     4. Install the Transformers library
 
         ```bash
         python3 -m pip install transformers
         ```
     5. (optional) Install NanoSAM (for the instance segmentation example)
+    6. Install the Clip Package
+
+        ```conda install --yes -c pytorch pytorch=1.7.1 torchvision cudatoolkit=11.0
+           pip install ftfy regex tqdm
+           pip install git+https://github.com/openai/CLIP.git
+        ```
 
 2. Install the NanoOWL package.
 


### PR DESCRIPTION
When running example 2, it requires attributes for the methods from the Clip Package, but doesn't have a reference to anywhere in Readme from where and what to install. So I have added that package install command. Also for live camera feed we will need aiohttp module.