### PR TITLE
 Fix image roi bug in OwlPredictor

### DIFF
--- a/nanoowl/owl_predictor.py
+++ b/nanoowl/owl_predictor.py
@@ -468,7 +468,7 @@ class OwlPredictor(torch.nn.Module):
         if text_encodings is None:
             text_encodings = self.encode_text(text)
 
-        rois = torch.tensor([[0, 0, image.height, image.width]], dtype=image_tensor.dtype, device=image_tensor.device)
+        rois = torch.tensor([[0, 0, image.width, image.height]], dtype=image_tensor.dtype, device=image_tensor.device)
 
         image_encodings = self.encode_rois(image_tensor, rois, pad_square=pad_square)
 


### PR DESCRIPTION
This pull request fixes #24.
The fix updates the `rois` tensor to use the correct dimensions, ensuring accurate encoding of image rois.