### PR TITLE
feat: enabled device camera input via browser for tree_demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ NanoOWL runs real-time on Jetson Orin Nano.
 
 | Repository/Tag | Date | Arch | Size |
 | :-- | :--: | :--: | :--: |
-| &nbsp;&nbsp;[`roylvzn/owlvit:1.0.0`](https://hub.docker.com/r/roylvzn/owlvit/tags) | `2025-12-21` | `arm64` | `9.66GB` |
+| &nbsp;&nbsp;[`roylvzn/owlvit:latest`](https://hub.docker.com/repository/docker/roylvzn/owlvit/general) | `2025-12-25` | `arm64` | `9.66GB` |
 
 1. Install the dependencies
 
@@ -207,7 +207,7 @@ live-edited text prompts.  To run the example
 2. Launch the demo
     ```bash
     cd examples/tree_demo
-    python3 tree_demo.py --camera 1 ../../data/owl_image_encoder_patch32.engine
+    python3 tree_demo.py ../../data/owl_image_encoder_patch32.engine
     ```
 3. Second, open your browser to ``http://<ip address>:7860``
 4. Type whatever prompt you like to see what works!  Here are some examples

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ NanoOWL runs real-time on Jetson Orin Nano.
 <a id="setup"></a>
 ## 🛠️ Setup
 
+| Repository/Tag | Date | Arch | Size |
+| :-- | :--: | :--: | :--: |
+| &nbsp;&nbsp;[`roylvzn/owlvit:1.0.0`](https://hub.docker.com/r/roylvzn/owlvit/tags) | `2025-12-21` | `arm64` | `9.66GB` |
+
 1. Install the dependencies
 
     1. Install PyTorch
@@ -203,7 +207,7 @@ live-edited text prompts.  To run the example
 2. Launch the demo
     ```bash
     cd examples/tree_demo
-    python3 tree_demo.py ../../data/owl_image_encoder_patch32.engine
+    python3 tree_demo.py --camera 1 ../../data/owl_image_encoder_patch32.engine
     ```
 3. Second, open your browser to ``http://<ip address>:7860``
 4. Type whatever prompt you like to see what works!  Here are some examples

--- a/examples/tree_demo/index.html
+++ b/examples/tree_demo/index.html
@@ -50,6 +50,10 @@
             width: 640px;
         }
 
+        #videoElement {
+            display: none;
+        }
+
     </style>
 
     <script type="text/javascript">
@@ -62,7 +66,10 @@
         }
 
         var ws = undefined
-        
+        var streaming = false
+
+        const canvas = document.createElement("canvas");
+        const ctx = canvas.getContext("2d");
         console.log(location.host);
 
         ws = new WebSocket("ws://" + location.host + "/ws");
@@ -97,6 +104,47 @@
                 console.log("Received message.");
                 camera_image.src = reader.result;
             }
+        };
+
+        async function startCamera() {
+            if (!ws || ws.readyState !== WebSocket.OPEN) {
+                console.warn("WebSocket not ready");
+                return;
+            }
+            ws.send("use_browser");
+            const video = document.getElementById("videoElement");
+
+            const stream = await navigator.mediaDevices.getUserMedia({
+                video: true,
+                audio: false
+            });
+
+            video.srcObject = stream;
+            await new Promise(resolve => {
+                video.onloadedmetadata = () => resolve();
+            });
+
+            await video.play();
+
+            canvas.width = video.videoWidth;
+            canvas.height = video.videoHeight;
+
+            console.log("Browser camera started:", canvas.width, canvas.height);
+
+            streaming = true;
+            sendFrameLoop(video);
+        }
+
+        function sendFrameLoop(video) {
+            if (!streaming || ws.readyState !== WebSocket.OPEN) return;
+
+            ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+
+            canvas.toBlob(function (blob) {
+                if (blob) ws.send(blob);
+            }, "image/jpeg", 0.7);
+
+            setTimeout(() => sendFrameLoop(video), 33);
         }
 
     </script>
@@ -106,7 +154,9 @@
         <h1>NanoOWL</h1>
         <img id="camera_image" src="" alt="Camera Image"/>
         <br/>
+        <button id="startButton" onclick="startCamera()">Use Browser</button>
         <input id="prompt_input" type="text" placeholder="[a face [an eye, a nose]]"/>
     </div>
+    <video id="videoElement" autoplay playsinline muted style="display:none;"></video>
 </body>
 </html>

--- a/nanoowl/owl_predictor.py
+++ b/nanoowl/owl_predictor.py
@@ -156,6 +156,12 @@ class OwlPredictor(torch.nn.Module):
         self.device = device
         self.model = OwlViTForObjectDetection.from_pretrained(model_name).to(self.device).eval()
         self.processor = OwlViTProcessor.from_pretrained(model_name)
+        self.image_encoder_engine = None
+        # if image_encoder_engine is None:
+        #     self.image_encoder_engine = OwlPredictor.load_image_encoder_engine(
+        #         image_encoder_engine,
+        #         image_encoder_engine_max_batch_size
+        #         )
         self.patch_size = _owl_get_patch_size(model_name)
         self.num_patches_per_side = self.image_size // self.patch_size
         self.box_bias = _owl_compute_box_bias(self.num_patches_per_side).to(self.device)

--- a/nanoowl/owl_predictor.py
+++ b/nanoowl/owl_predictor.py
@@ -157,11 +157,6 @@ class OwlPredictor(torch.nn.Module):
         self.model = OwlViTForObjectDetection.from_pretrained(model_name).to(self.device).eval()
         self.processor = OwlViTProcessor.from_pretrained(model_name)
         self.image_encoder_engine = None
-        # if image_encoder_engine is None:
-        #     self.image_encoder_engine = OwlPredictor.load_image_encoder_engine(
-        #         image_encoder_engine,
-        #         image_encoder_engine_max_batch_size
-        #         )
         self.patch_size = _owl_get_patch_size(model_name)
         self.num_patches_per_side = self.image_size // self.patch_size
         self.box_bias = _owl_compute_box_bias(self.num_patches_per_side).to(self.device)


### PR DESCRIPTION
This PR adds optional browser-based camera input to tree_demo, allowing users to run the demo without needing a USB/CSI camera attached.

The demo now:
-Defaults to attempting a local V4L2 camera (unchanged behavior)
-Allows users to explicitly switch to a browser device camera at runtime with a button
-Streams browser camera frames to the backend over WebSockets for inference

Key changes
-Added a button to enable browser camera streaming on demand
-Introduced a runtime switch (USE_BROWSER) to select the active image source
-Integrated browser-sent JPEG frames into the existing inference loop
-Preserved original demo behavior for systems with local cameras